### PR TITLE
Idiot Check The Second

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -471,27 +471,28 @@ simulated function GetDamagePreview(StateObjectReference TargetRef, XComGameStat
 					//  ignores PlusOne as there is no good way to add them up
 				}
 			}
-			// Issue #237 start
-			// Treat new CH upgrade damage as base damage unless a tag is specified
-			foreach WeaponUpgradeTemplates(WeaponUpgradeTemplate)
-			{
-				if ((!bIgnoreBaseDamage && DamageTag == '') || WeaponUpgradeTemplate.CHBonusDamage.Tag == DamageTag)
-				{
-					UpgradeTemplateBonusDamage = WeaponUpgradeTemplate.CHBonusDamage;
-
-					ModifyDamageValue(UpgradeTemplateBonusDamage, TargetUnit, AppliedDamageTypes);
-
-					UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
-					UpgradeDamageValue.Spread += UpgradeTemplateBonusDamage.Spread;
-					UpgradeDamageValue.Crit += UpgradeTemplateBonusDamage.Crit;
-					UpgradeDamageValue.Pierce += UpgradeTemplateBonusDamage.Pierce;
-					UpgradeDamageValue.Rupture += UpgradeTemplateBonusDamage.Rupture;
-					UpgradeDamageValue.Shred += UpgradeTemplateBonusDamage.Shred;
-					//  ignores PlusOne as there is no good way to add them up
-				}
-			}
-			// Issue #237 end
 		}
+		// Issue #237 start
+		// Treat new CH upgrade damage as base damage unless a tag is specified
+		WeaponUpgradeTemplates = SourceWeapon.GetMyWeaponUpgradeTemplates();
+		foreach WeaponUpgradeTemplates(WeaponUpgradeTemplate)
+		{
+			if ((!bIgnoreBaseDamage && DamageTag == '') || WeaponUpgradeTemplate.CHBonusDamage.Tag == DamageTag)
+			{
+				UpgradeTemplateBonusDamage = WeaponUpgradeTemplate.CHBonusDamage;
+
+				ModifyDamageValue(UpgradeTemplateBonusDamage, TargetUnit, AppliedDamageTypes);
+
+				UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
+				UpgradeDamageValue.Spread += UpgradeTemplateBonusDamage.Spread;
+				UpgradeDamageValue.Crit += UpgradeTemplateBonusDamage.Crit;
+				UpgradeDamageValue.Pierce += UpgradeTemplateBonusDamage.Pierce;
+				UpgradeDamageValue.Rupture += UpgradeTemplateBonusDamage.Rupture;
+				UpgradeDamageValue.Shred += UpgradeTemplateBonusDamage.Shred;
+				//  ignores PlusOne as there is no good way to add them up
+			}
+		}
+		// Issue #237 end
 	}
 	BonusEffectDamageValue = GetBonusEffectDamageValue(AbilityState, SourceUnit, SourceWeapon, TargetRef);
 	ModifyDamageValue(BonusEffectDamageValue, TargetUnit, AppliedDamageTypes);
@@ -807,28 +808,29 @@ simulated function int CalculateDamageAmount(const out EffectAppliedData ApplyEf
 					//  ignores PlusOne as there is no good way to add them up
 				}
 			}
-			// Issue #237 start
-			// Treat new CH upgrade damage as base damage unless a tag is specified
-			foreach WeaponUpgradeTemplates(WeaponUpgradeTemplate)
-			{
-				if ((!bIgnoreBaseDamage && DamageTag == '') || WeaponUpgradeTemplate.CHBonusDamage.Tag == DamageTag)
-				{
-					UpgradeTemplateBonusDamage = WeaponUpgradeTemplate.CHBonusDamage;
-
-					if (UpgradeTemplateBonusDamage.Damage > 0) bHadAnyDamage = true;
-					bWasImmune = bWasImmune && ModifyDamageValue(UpgradeTemplateBonusDamage, kTarget, AppliedDamageTypes);
-
-					UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
-					UpgradeDamageValue.Spread += UpgradeTemplateBonusDamage.Spread;
-					UpgradeDamageValue.Crit += UpgradeTemplateBonusDamage.Crit;
-					UpgradeDamageValue.Pierce += UpgradeTemplateBonusDamage.Pierce;
-					UpgradeDamageValue.Rupture += UpgradeTemplateBonusDamage.Rupture;
-					UpgradeDamageValue.Shred += UpgradeTemplateBonusDamage.Shred;
-					//  ignores PlusOne as there is no good way to add them up
-				}
-			}
-			// Issue #237 end
 		}
+		// Issue #237 start
+		// Treat new CH upgrade damage as base damage unless a tag is specified
+		WeaponUpgradeTemplates = kSourceItem.GetMyWeaponUpgradeTemplates();
+		foreach WeaponUpgradeTemplates(WeaponUpgradeTemplate)
+		{
+			if ((!bIgnoreBaseDamage && DamageTag == '') || WeaponUpgradeTemplate.CHBonusDamage.Tag == DamageTag)
+			{
+				UpgradeTemplateBonusDamage = WeaponUpgradeTemplate.CHBonusDamage;
+
+				if (UpgradeTemplateBonusDamage.Damage > 0) bHadAnyDamage = true;
+				bWasImmune = bWasImmune && ModifyDamageValue(UpgradeTemplateBonusDamage, kTarget, AppliedDamageTypes);
+
+				UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
+				UpgradeDamageValue.Spread += UpgradeTemplateBonusDamage.Spread;
+				UpgradeDamageValue.Crit += UpgradeTemplateBonusDamage.Crit;
+				UpgradeDamageValue.Pierce += UpgradeTemplateBonusDamage.Pierce;
+				UpgradeDamageValue.Rupture += UpgradeTemplateBonusDamage.Rupture;
+				UpgradeDamageValue.Shred += UpgradeTemplateBonusDamage.Shred;
+				//  ignores PlusOne as there is no good way to add them up
+			}
+		}
+		// Issue #237 end
 	}
 
 	// non targeted objects take the environmental damage amount
@@ -1371,27 +1373,28 @@ function CalculateDamageValues(XComGameState_Item SourceWeapon, XComGameState_Un
 					//  ignores PlusOne as there is no good way to add them up
 				}
 			}
-			// Issue #237 start
-			// Treat new CH upgrade damage as base damage unless a tag is specified
-			foreach WeaponUpgradeTemplates(WeaponUpgradeTemplate)
-			{
-				if ((!bIgnoreBaseDamage && DamageTag == '') || WeaponUpgradeTemplate.CHBonusDamage.Tag == DamageTag)
-				{
-					UpgradeTemplateBonusDamage = WeaponUpgradeTemplate.CHBonusDamage;
-					
-					ModifyDamageValue(UpgradeTemplateBonusDamage, TargetUnit, AppliedDamageTypes);
-
-					DamageInfo.UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
-					DamageInfo.UpgradeDamageValue.Spread += UpgradeTemplateBonusDamage.Spread;
-					DamageInfo.UpgradeDamageValue.Crit += UpgradeTemplateBonusDamage.Crit;
-					DamageInfo.UpgradeDamageValue.Pierce += UpgradeTemplateBonusDamage.Pierce;
-					DamageInfo.UpgradeDamageValue.Rupture += UpgradeTemplateBonusDamage.Rupture;
-					DamageInfo.UpgradeDamageValue.Shred += UpgradeTemplateBonusDamage.Shred;
-					//  ignores PlusOne as there is no good way to add them up
-				}
-			}
-			// Issue #237 end
 		}
+		// Issue #237 start
+		// Treat new CH upgrade damage as base damage unless a tag is specified
+		WeaponUpgradeTemplates = SourceWeapon.GetMyWeaponUpgradeTemplates();
+		foreach WeaponUpgradeTemplates(WeaponUpgradeTemplate)
+		{
+			if ((!bIgnoreBaseDamage && DamageTag == '') || WeaponUpgradeTemplate.CHBonusDamage.Tag == DamageTag)
+			{
+				UpgradeTemplateBonusDamage = WeaponUpgradeTemplate.CHBonusDamage;
+				
+				ModifyDamageValue(UpgradeTemplateBonusDamage, TargetUnit, AppliedDamageTypes);
+
+				DamageInfo.UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
+				DamageInfo.UpgradeDamageValue.Spread += UpgradeTemplateBonusDamage.Spread;
+				DamageInfo.UpgradeDamageValue.Crit += UpgradeTemplateBonusDamage.Crit;
+				DamageInfo.UpgradeDamageValue.Pierce += UpgradeTemplateBonusDamage.Pierce;
+				DamageInfo.UpgradeDamageValue.Rupture += UpgradeTemplateBonusDamage.Rupture;
+				DamageInfo.UpgradeDamageValue.Shred += UpgradeTemplateBonusDamage.Shred;
+				//  ignores PlusOne as there is no good way to add them up
+			}
+		}
+		// Issue #237 end
 	}
 
 	DamageInfo.BonusEffectDamageValue = GetBonusEffectDamageValue(AbilityState, SourceUnit, SourceWeapon, TargetUnit.GetReference());


### PR DESCRIPTION
Pulled the damage bonus insertion out of the check to allow weapon upgrades, because that's only true on a missed shot.